### PR TITLE
update package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "laravel-shield/bitbucket",
+    "name": "laravel-shield/bitbucket-server",
     "description": "A bitbucket server service for shield.",
     "type": "library",
     "license": "MIT",


### PR DESCRIPTION
I think we should update the name, as bitbucket (normal/hosted) may support verifying webhooks in the future, and it makes it clear what the package is for.